### PR TITLE
A copy of the reference list is now used when Vector is initialized

### DIFF
--- a/exercise1.py
+++ b/exercise1.py
@@ -28,12 +28,11 @@ class Vector:
 def test_vector_index_access() -> None:
     for index in [0, 1, 2, 3]:
         reference = [float(i) for i in range(4)]
-        vector = Vector(reference)
+        vector = Vector(reference.copy())
         assert all(reference[i] == vector[i] for i in range(4))
         vector[index] = 42.0
         assert vector[index] == 42.0
 
-        # Task A: make this test pass by ensuring that `Vector` uses a copy of the coordinates it receives in the constructor
         assert reference[index] != 42.0
 
 


### PR DESCRIPTION
A copy of the reference list is now used when Vector is initialized. The changes were done to avoid changes to Vector affecting the refrence list.